### PR TITLE
com.utilities.extensions 1.0.4

### DIFF
--- a/Utilities.Extensions/Packages/com.utilities.extensions/Editor/ScriptableObjectExtensions.cs
+++ b/Utilities.Extensions/Packages/com.utilities.extensions/Editor/ScriptableObjectExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -168,14 +169,19 @@ namespace Utilities.Extensions.Editor
         {
             // FindAssets uses tags check documentation for more info
             var guids = AssetDatabase.FindAssets($"t:{typeof(T).Name}");
-            var instances = new T[guids.Length];
+            var instances = new List<T>();
 
             for (var i = 0; i < guids.Length; i++)
             {
-                instances[i] = AssetDatabase.LoadAssetAtPath<T>(AssetDatabase.GUIDToAssetPath(guids[i]));
+                var instance = AssetDatabase.LoadAssetAtPath<T>(AssetDatabase.GUIDToAssetPath(guids[i]));
+
+                if (instance.IsNotNull())
+                {
+                    instances[i] = instance;
+                }
             }
 
-            return instances;
+            return instances.ToArray();
         }
     }
 }

--- a/Utilities.Extensions/Packages/com.utilities.extensions/package.json
+++ b/Utilities.Extensions/Packages/com.utilities.extensions/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Extensions",
   "description": "Common extensions for Unity types (UPM)",
   "keywords": [],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.extensions#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.extensions/releases",


### PR DESCRIPTION
- Updated `ScriptableObject.GetAllInstances<T>` to filter null asset references