### PR TITLE
com.utilities.extensions 1.1.7

### DIFF
--- a/Utilities.Extensions/Packages/com.utilities.extensions/Editor/PropertyDrawers/SerializedDictionaryPropertyDrawer.cs
+++ b/Utilities.Extensions/Packages/com.utilities.extensions/Editor/PropertyDrawers/SerializedDictionaryPropertyDrawer.cs
@@ -57,14 +57,24 @@ namespace Utilities.Extensions.Editor
                 serializedDictionary.selectedElement = index;
             }
 
+            var keyHeight = key.propertyType == SerializedPropertyType.String
+                ? EditorGUILayoutExtensions.GetTextAreaHeight(key, rect.width)
+                : EditorGUIUtility.singleLineHeight;
+            var keyRect = new Rect(rect.x, rect.y, rect.width, keyHeight);
+            var valueHeight = value.propertyType == SerializedPropertyType.String
+                ? EditorGUILayoutExtensions.GetTextAreaHeight(value, rect.width)
+                : EditorGUIUtility.singleLineHeight;
+            var valueRect = new Rect(rect.x, rect.y + keyHeight + EditorGUIUtility.standardVerticalSpacing, rect.width, valueHeight);
+
             EditorGUI.BeginChangeCheck();
-
-            var lineHeight = EditorGUIUtility.singleLineHeight;
-            var keyRect = new Rect(rect.x, rect.y, rect.width, lineHeight);
-            var valueHeight = EditorGUILayoutExtensions.GetTextAreaHeight(value, rect.width);
-            var valueRect = new Rect(rect.x, rect.y + lineHeight + EditorGUIUtility.standardVerticalSpacing, rect.width, valueHeight);
-
             EditorGUI.PropertyField(keyRect, key, GUIContent.none);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                serializedDictionary.ApplyModifiedProperties();
+            }
+
+            EditorGUI.BeginChangeCheck();
 
             if (value.propertyType == SerializedPropertyType.String)
             {
@@ -87,7 +97,11 @@ namespace Utilities.Extensions.Editor
             var (key, value) = serializedDictionary.GetArrayElementAtIndex(index);
 
             // Calculate heights taking into account multi-line serialized properties for value property
-            var keyHeight = EditorGUI.GetPropertyHeight(key, true);
+            var keyHeight = key.propertyType switch
+            {
+                SerializedPropertyType.String => EditorGUILayoutExtensions.GetTextAreaHeight(key, EditorGUIUtility.currentViewWidth),
+                _ => EditorGUI.GetPropertyHeight(key, true)
+            };
             var valueHeight = value.propertyType switch
             {
                 SerializedPropertyType.String => EditorGUILayoutExtensions.GetTextAreaHeight(value, EditorGUIUtility.currentViewWidth),

--- a/Utilities.Extensions/Packages/com.utilities.extensions/package.json
+++ b/Utilities.Extensions/Packages/com.utilities.extensions/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Extensions",
   "description": "Common extensions for Unity types (UPM)",
   "keywords": [],
-  "version": "1.1.6",
+  "version": "1.1.7",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.extensions#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.extensions/releases",


### PR DESCRIPTION
- fixed serialized dictionary line height, serialization, and support for non string keys and values.